### PR TITLE
Abstract double ratchet encryption in to two simple functions

### DIFF
--- a/did/GenerateDidDocument.go
+++ b/did/GenerateDidDocument.go
@@ -10,6 +10,11 @@ type GenerateDidDocument struct {
 	Resolver ResolverInterface
 }
 
+func Generate(id string, resolver ResolverInterface, w *wallet.Wallet, publish bool, serviceEndpoints ...Service) (*Document, error) {
+	g := GenerateDidDocument{Resolver: resolver}
+	return g.Generate(id, w, publish, serviceEndpoints...)
+}
+
 func (g *GenerateDidDocument) Generate(id string, w *wallet.Wallet, publish bool, serviceEndpoints ...Service) (*Document, error) {
 	var doc Document
 	doc.Context = "https://w3id.org/did/v1"

--- a/double-ratchet/DoubleRatchet.go
+++ b/double-ratchet/DoubleRatchet.go
@@ -1,0 +1,124 @@
+package doubleratchet
+
+import (
+	"encoding/json"
+	"github.com/Vivvo/go-sdk/did"
+	"github.com/Vivvo/go-sdk/models"
+	"github.com/Vivvo/go-sdk/utils"
+	"github.com/Vivvo/go-wallet"
+	"github.com/google/uuid"
+	"log"
+)
+
+type Encryption struct {
+	wallet   *wallet.Wallet
+	resolver did.ResolverInterface
+}
+
+/*
+	recipientDid - public or pairwise did: we will do the math
+*/
+func (e *Encryption) Encrypt(recipientDid string, message interface{}) (*wallet.RatchetPayload, error) {
+	m := e.wallet.Messaging()
+
+	tags := struct{
+		PublicDid string
+	}{
+		PublicDid: recipientDid,
+	}
+	tj, err := json.Marshal(tags)
+
+	existing, err := e.wallet.Contacts().Read(recipientDid)
+	if err != nil {
+		// no existing contact, still need to check if recipientDid a publicDid
+		eBytes, err := e.wallet.Contacts().FindByTags(tj)
+		if err == nil {
+			existing = string(eBytes)
+		}
+	}
+
+	var pairwise string
+	if existing == "" {
+		pairwise = utils.ClientIdToDid(uuid.New())
+		_, err = did.Generate(pairwise, e.resolver, e.wallet, true)
+
+		ddoc, err := e.resolver.Resolve(recipientDid)
+		if err != nil {
+			return nil, err
+		}
+
+		pubkey, err := ddoc.GetKeyByType(wallet.TypeEd25519KeyExchange2018)
+		if err != nil {
+			return nil, err
+		}
+		err = m.InitDoubleRatchet(pairwise, pubkey.PublicKeyBase58)
+		if err != nil {
+			return nil, err
+		}
+
+		contact := models.Contact{Id: pairwise, PairwiseDid: pairwise, PublicDid: recipientDid}
+		cj, err := json.Marshal(contact)
+		err = e.wallet.Contacts().Create(pairwise, string(cj), tj)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		var c models.Contact
+		err := json.Unmarshal([]byte(existing), &c)
+		if err != nil {
+			return nil, err
+		}
+
+		pairwise = c.PairwiseDid
+	}
+
+	j, err := json.Marshal(message)
+	if err != nil {
+		return nil, err
+	}
+	return m.RatchetEncrypt(pairwise, string(j))
+}
+
+// TODO: Existing adapters have pubDid in config, need to handle adding to userProfile
+func (e *Encryption) Decrypt(encryptedMessage *wallet.RatchetPayload, obj interface{}) error {
+	m := e.wallet.Messaging()
+
+	pairwise := utils.ClientIdToDid(uuid.New())
+	_, err := did.Generate(pairwise, e.resolver, e.wallet, false)
+
+	log.Println(encryptedMessage.Sender)
+	ddoc, err := e.resolver.Resolve(encryptedMessage.Sender)
+	if err != nil {
+		return err
+	}
+
+	pubkey, err := ddoc.GetKeyByType(wallet.TypeEd25519KeyExchange2018)
+	if err != nil {
+		return err
+	}
+
+	profiles, _ := e.wallet.UserProfile().ReadAll()
+	var ups []models.UserProfile
+	_ = json.Unmarshal(profiles, &ups)
+	err = m.InitDoubleRatchetWithWellKnownPublicKey(ups[0].PublicDid, pairwise, pubkey.PublicKeyBase58)
+	if err != nil {
+		return err
+	}
+
+	msg, err := m.RatchetDecrypt(pairwise, encryptedMessage)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal([]byte(msg), obj)
+
+	return nil
+}
+
+func IsDoubleRatchetEncrypted(msg interface{}) bool {
+	if payload, ok := msg.(map[string]interface{}); ok {
+		return payload["sender"] != nil && payload["dhs"] != nil && payload["pn"] != nil && payload["ns"] != nil && payload["payload"] != nil && payload["initializationKey"] != nil
+	} else {
+		return false
+	}
+}

--- a/double-ratchet/DoubleRatchet_test.go
+++ b/double-ratchet/DoubleRatchet_test.go
@@ -3,6 +3,7 @@ package doubleratchet
 import (
 	"crypto/rand"
 	"encoding/json"
+	"fmt"
 	"github.com/Vivvo/go-sdk/did"
 	"github.com/Vivvo/go-sdk/models"
 	"github.com/Vivvo/go-sdk/utils"
@@ -44,8 +45,9 @@ func TestSuite(t *testing.T) {
 		name string
 		fn   func(t *testing.T)
 	}{
-		//{"testEncryptMessageWithNewContact", testEncryptMessageWithNewContact},
-		{"testEncryptMessageWithExistingContact", testEncryptMessageWithExistingContact},
+		{"testEncryptMessageWithNewPartner", testEncryptMessageWithNewPartner},
+		{"testEncryptMessageWithExistingPartner", testEncryptMessageWithExistingPartner},
+		{"testEncryptMessageWithExistingPartnerLoop", testEncryptMessageWithExistingPartnerLoop},
 	}
 
 	for _, tt := range tests {
@@ -61,7 +63,7 @@ func TestSuite(t *testing.T) {
 
 }
 
-func testEncryptMessageWithNewContact(t *testing.T) {
+func testEncryptMessageWithNewPartner(t *testing.T) {
 
 	bobMessaging := Encryption{bobWallet, resolver}
 	payload, err := bobMessaging.Encrypt(alicePublicDid, "Hi, Alice!")
@@ -83,16 +85,14 @@ func testEncryptMessageWithNewContact(t *testing.T) {
 	}
 }
 
-func testEncryptMessageWithExistingContact(t *testing.T) {
-	testEncryptMessageWithNewContact(t) // run new contact to cover initdoubleratchet
+func testEncryptMessageWithExistingPartner(t *testing.T) {
+	testEncryptMessageWithNewPartner(t) // run new partner to cover initdoubleratchet, now they are partners
 
 	bobMessaging := Encryption{bobWallet, resolver}
 	payload, err := bobMessaging.Encrypt(alicePublicDid, "Hi, Alice!")
 	if err != nil {
 		t.Error(err.Error())
 	}
-
-	log.Println(payload)
 
 	aliceMessaging := Encryption{aliceWallet, resolver}
 	var msg string
@@ -103,6 +103,14 @@ func testEncryptMessageWithExistingContact(t *testing.T) {
 
 	if strings.Compare(msg, "Hi, Alice!") != 0 {
 		t.Errorf("Expected: %s, Actual: %s", "Hi, Alice!", msg)
+	}
+}
+
+func testEncryptMessageWithExistingPartnerLoop(t *testing.T) {
+	testEncryptMessageWithNewPartner(t) // run new partner to cover initdoubleratchet, now they are partners
+
+	for i := 0; i < 10; i++ {
+		t.Run(fmt.Sprintf("testEncryptMessageWithExistingPartner %d", i), testEncryptMessageWithExistingPartner)
 	}
 }
 

--- a/double-ratchet/DoubleRatchet_test.go
+++ b/double-ratchet/DoubleRatchet_test.go
@@ -1,0 +1,155 @@
+package doubleratchet
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"github.com/Vivvo/go-sdk/did"
+	"github.com/Vivvo/go-sdk/models"
+	"github.com/Vivvo/go-sdk/utils"
+	"github.com/Vivvo/go-wallet"
+	"github.com/google/uuid"
+	"log"
+	"os"
+	"strings"
+	"testing"
+)
+
+type DoubleRatchetMockResolver struct {
+	ddocs map[string]*did.Document
+}
+
+func NewDoubleRatchetMockResolver() *DoubleRatchetMockResolver {
+	m := DoubleRatchetMockResolver{}
+	m.ddocs = make(map[string]*did.Document, 0)
+	return &m
+}
+
+func (m *DoubleRatchetMockResolver) Resolve(did string) (*did.Document, error) {
+	return m.ddocs[did], nil
+}
+func (m *DoubleRatchetMockResolver) Register(ddoc *did.Document, other ...string) error {
+	m.ddocs[ddoc.Id] = ddoc
+	return nil
+}
+
+var resolver did.ResolverInterface
+var aliceWallet *wallet.Wallet
+var bobWallet *wallet.Wallet
+var bobPublicDid string
+var alicePublicDid string
+
+func TestSuite(t *testing.T) {
+
+	tests := []struct {
+		name string
+		fn   func(t *testing.T)
+	}{
+		//{"testEncryptMessageWithNewContact", testEncryptMessageWithNewContact},
+		{"testEncryptMessageWithExistingContact", testEncryptMessageWithExistingContact},
+	}
+
+	for _, tt := range tests {
+		err := setup()
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+
+		t.Run(tt.name, tt.fn)
+
+		teardown()
+	}
+
+}
+
+func testEncryptMessageWithNewContact(t *testing.T) {
+
+	bobMessaging := Encryption{bobWallet, resolver}
+	payload, err := bobMessaging.Encrypt(alicePublicDid, "Hi, Alice!")
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	log.Println(payload)
+
+	aliceMessaging := Encryption{aliceWallet, resolver}
+	var msg string
+	err = aliceMessaging.Decrypt(payload, &msg)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	if strings.Compare(msg, "Hi, Alice!") != 0 {
+		t.Errorf("Expected: %s, Actual: %s", "Hi, Alice!", msg)
+	}
+}
+
+func testEncryptMessageWithExistingContact(t *testing.T) {
+	testEncryptMessageWithNewContact(t) // run new contact to cover initdoubleratchet
+
+	bobMessaging := Encryption{bobWallet, resolver}
+	payload, err := bobMessaging.Encrypt(alicePublicDid, "Hi, Alice!")
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	log.Println(payload)
+
+	aliceMessaging := Encryption{aliceWallet, resolver}
+	var msg string
+	err = aliceMessaging.Decrypt(payload, &msg)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	if strings.Compare(msg, "Hi, Alice!") != 0 {
+		t.Errorf("Expected: %s, Actual: %s", "Hi, Alice!", msg)
+	}
+}
+
+func setup() error {
+	var err error
+	os.Setenv("DEBUG", "true")
+
+	resolver = NewDoubleRatchetMockResolver()
+
+	aliceKey := make([]byte, 32)
+	rand.Read(aliceKey)
+	aliceWallet, err = wallet.Create(aliceKey, "alice.Wallet")
+	if err != nil {
+		return err
+	}
+
+	g := did.GenerateDidDocument{resolver}
+	alicePublicDid = utils.ClientIdToDid(uuid.New())
+	_, err = g.Generate(alicePublicDid, aliceWallet, true)
+	if err != nil {
+		return err
+	}
+	aliceProfile := models.UserProfile{Id: alicePublicDid, PublicDid: alicePublicDid}
+	aj, _ := json.Marshal(aliceProfile)
+	aliceWallet.UserProfile().Create(alicePublicDid, string(aj), nil)
+
+	bobKey := make([]byte, 32)
+	rand.Read(bobKey)
+	bobWallet, err = wallet.Create(bobKey, "bob.Wallet")
+	if err != nil {
+		return err
+	}
+
+	bobPublicDid = utils.ClientIdToDid(uuid.New())
+	_, err = g.Generate(bobPublicDid, bobWallet, true)
+	if err != nil {
+		return err
+	}
+
+	bobProfile := models.UserProfile{Id: bobPublicDid, PublicDid: bobPublicDid}
+	bj, _ := json.Marshal(bobProfile)
+	bobWallet.UserProfile().Create(bobPublicDid, string(bj), nil)
+
+	return err
+}
+
+func teardown() {
+	os.Remove("alice.Wallet")
+	os.Remove("bob.Wallet")
+}

--- a/models/ContactModel.go
+++ b/models/ContactModel.go
@@ -1,0 +1,7 @@
+package models
+
+type Contact struct {
+	Id             string
+	PairwiseDid    string
+	PublicDid      string
+}

--- a/models/RatchetPartner.go
+++ b/models/RatchetPartner.go
@@ -1,6 +1,6 @@
 package models
 
-type Contact struct {
+type RatchetPartner struct {
 	Id             string
 	PairwiseDid    string
 	PublicDid      string

--- a/models/UserProfileModel.go
+++ b/models/UserProfileModel.go
@@ -1,0 +1,6 @@
+package models
+
+type UserProfile struct {
+	Id        string `json:"id"`
+	PublicDid string `json:"publicDid"`
+}

--- a/trust-provider/trust_provider.go
+++ b/trust-provider/trust_provider.go
@@ -210,6 +210,63 @@ func (t *TrustProvider) createPairwiseDid(w *wallet.Wallet, resolver did.Resolve
 	return document, nil
 }
 
+//*did.VerifiableClaim
+//	var pairwiseDoc *did.Document
+func (t *TrustProvider) doubleRatchetDecryptBody(rp map[string]interface{}, r *http.Request) (map[string]interface{}, error) {
+	if t.isDoubleRatchetEncrypted(rp) {
+		// Must be an encrypted payload!
+		var body interface{}
+		logger := utils.Logger(r.Context())
+
+		messaging := t.Wallet.Messaging()
+
+		// check for existing contact
+		var ratchetPayload = wallet.RatchetPayload{}
+		err := utils.ReadBody(&ratchetPayload, r)
+		if err != nil {
+			logger.Errorf("Problem unmarshalling onboarding request ratchetPayload", "error", err.Error())
+			return nil, err
+		}
+
+		ourDid := getWalletConfigValue(WalletConfigDID)
+		pairwiseDoc, err = t.createPairwiseDid(t.Wallet, t.resolver)
+		if err != nil {
+			return nil, err
+		}
+
+		err = messaging.InitDoubleRatchetWithWellKnownPublicKey(ourDid, pairwiseDoc.Id, ratchetPayload.InitializationKey)
+		if err != nil {
+			return nil, err
+		}
+
+		payload, err := messaging.RatchetDecrypt(pairwiseDoc.Id, &ratchetPayload)
+		if err != nil {
+			return nil, err
+		}
+
+		err = json.Unmarshal([]byte(payload), &body)
+		if err != nil {
+			return nil, err
+		}
+
+		var ve []string
+		vc, ve = t.parseVerifiableCredential(body, logger)
+		if len(ve) > 0 {
+			e, err := json.Marshal(ve)
+			if err == nil {
+				err = errors.New(string(e))
+			}
+			logger.Errorf("Problem verifying the Verifiable Credential", "error", ve)
+			return nil, err
+		}
+
+		return vc.Claim, nil
+	} else {
+		return rp, nil // not a ratchet payload
+	}
+
+}
+
 func (t *TrustProvider) register(w http.ResponseWriter, r *http.Request) {
 
 	logger := utils.Logger(r.Context())
@@ -222,64 +279,14 @@ func (t *TrustProvider) register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var onboardingVC *did.VerifiableClaim
-	var pairwiseDoc *did.Document
+	//var onboardingVC *did.VerifiableClaim
+	//var pairwiseDoc *did.Document
 	if b, ok := body.(map[string]interface{}); ok {
-		if b["sender"] != nil && b["dhs"] != nil && b["pn"] != nil && b["ns"] != nil && b["payload"] != nil && b["initializationKey"] != nil {
-			// Must be an encrypted payload!
-			logger := utils.Logger(r.Context())
-
-			messaging := t.Wallet.Messaging()
-
-			var ratchetPayload = wallet.RatchetPayload{}
-			err = utils.ReadBody(&ratchetPayload, r)
-
-			if err != nil {
-				logger.Errorf("Problem unmarshalling onboarding request ratchetPayload", "error", err.Error())
-				utils.SetErrorStatus(err, http.StatusBadRequest, w)
-				return
-			}
-
-			ourDid := getWalletConfigValue(WalletConfigDID)
-			pairwiseDoc, err = t.createPairwiseDid(t.Wallet, t.resolver)
-			if err != nil {
-				utils.SendError(err, w)
-				return
-			}
-
-			err = messaging.InitDoubleRatchetWithWellKnownPublicKey(ourDid, pairwiseDoc.Id, ratchetPayload.InitializationKey)
-			if err != nil {
-				utils.SendError(err, w)
-				return
-			}
-
-			payload, err := messaging.RatchetDecrypt(pairwiseDoc.Id, &ratchetPayload)
-			if err != nil {
-				utils.SendError(err, w)
-				return
-			}
-
-			err = json.Unmarshal([]byte(payload), &body)
-			if err != nil {
-				utils.SendError(err, w)
-				return
-			}
-
-			var ve []string
-			onboardingVC, ve = t.parseVerifiableCredential(body, logger)
-			if len(ve) > 0 {
-				e, err := json.Marshal(ve)
-				if err == nil {
-					err = errors.New(string(e))
-				}
-				logger.Errorf("Problem verifying the Verifiable Credential", "error", ve)
-				utils.SetErrorStatus(err, http.StatusBadRequest, w)
-				return
-			}
-
-			body = onboardingVC.Claim
+		body, err = t.doubleRatchetDecryptBody(b, r)
+		if err != nil {
+			utils.SendError(err, w)
+			return
 		}
-
 	}
 
 	s, n, b, arrs, err := t.parseParameters(body, t.onboarding.Parameters, r)
@@ -352,12 +359,12 @@ func (t *TrustProvider) register(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var vc *wallet.RatchetPayload
-	if (onboardingVC != nil || s["did"] != "") && len(t.onboarding.Claims) > 0 {
+	if (s[did.SubjectClaim] != "" || s["did"] != "") && len(t.onboarding.Claims) > 0 {
 		var subject string
 		if s["did"] != "" {
 			subject = s["did"]
 		} else {
-			subject = onboardingVC.Claim[did.SubjectClaim].(string)
+			subject = s[did.SubjectClaim]
 		}
 
 		c := make(map[string]interface{})
@@ -526,6 +533,16 @@ func (t *TrustProvider) handleRule(rule Rule) http.HandlerFunc {
 			utils.SetErrorStatus(err, http.StatusBadRequest, w)
 			return
 		}
+
+		//var incomingVc *did.VerifiableClaim
+		//var pairwiseDoc *did.Document
+		//if b, ok := body.(map[string]interface{}); ok {
+		//	body, err = t.doubleRatchetDecryptBody(incomingVc, pairwiseDoc, b, r)
+		//	if err != nil {
+		//		utils.SendError(err, w)
+		//		return
+		//	}
+		//}
 
 		s, n, b, a, err := t.parseParameters(body, rule.Parameters, r)
 		if err != nil {


### PR DESCRIPTION
Instead of having the implementing services figure out if they need to initdoubleratchet, this implementation allows us to simply call encrypt or decrypt and it will figure out whether it needs to initialize and whether to use pairwise or publicDid.